### PR TITLE
Fix `tag-version` GH workflow trigger

### DIFF
--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -3,7 +3,7 @@ name: Tag the new version of the hook
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
 
 jobs:
   tag-version:


### PR DESCRIPTION
`tag-version.yml` workflow was being triggered to run on push to the `master` branch (which doesn't
exist), while it should use the `main` branch.