### PR TITLE
Fix `check-hooks-pr` workflow not failing when the version is unchanged

### DIFF
--- a/.github/workflows/check-hooks-pr.yml
+++ b/.github/workflows/check-hooks-pr.yml
@@ -17,10 +17,6 @@ jobs:
       - name: Check Git LFS for updates
         run: |
           ./scripts/update-from-git-lfs.sh
-      
-      - name: Run basic tests
-        run: |
-          make basic-tests
 
       - name: Update the CHANGELOG.md
         run: |

--- a/scripts/update-changelog.sh
+++ b/scripts/update-changelog.sh
@@ -22,8 +22,8 @@ if [[ -n $UNTRACKED_HOOKS ]]; then
 \n### Added
 
 - Added new hook(s) from Git LFS ($SEP_UNTRACKED_HOOKS)
-- ATTENTION: We need to update the pre-commit-hooks.yaml, README.md files and the tests before releasing.
-As it is now, the tests should break when trying to merge this PR.\n
+- ATTENTION: We need to update the pre-commit-hooks.yaml, README.md, hook-wrappers files and the tests before releasing.
+As it is now, the tests should break when submitting a PR.\n
 EOF
 )
 fi
@@ -54,8 +54,8 @@ if [[ -n $REMOVED_HOOKS ]]; then
 \n### Removed
 
 - Removed hook(s) from Git LFS ($SEP_REMOVED_HOOKS)
-- ATTENTION: We need to update the pre-commit-hooks.yaml, README.md files and the tests before releasing.
-As it is now, the tests should break when trying to merge this PR.
+- ATTENTION: We need to update the pre-commit-hooks.yaml, README.md, hook-wrappers files and the tests before releasing.
+As it is now, the tests should break when submitting a PR.\n
 EOF
 )
 fi

--- a/scripts/update-from-git-lfs.sh
+++ b/scripts/update-from-git-lfs.sh
@@ -20,7 +20,9 @@ if dpkg --compare-versions $LFS_LATEST_VERSION eq $LFS_CURRENT_VERSION; then
     # there are no changes to its Git hooks (this makes also
     # the workflow's running durations shorter when there are no updates)
     echo "git-lfs version is unchanged ($LFS_CURRENT_VERSION). Exiting..."
-    exit 0
+    # TODO: Handle exit codes so that the GH action doesn't show as failed, but
+    # prints a message for example
+    exit 1
 fi
 
 if dpkg --compare-versions $LFS_LATEST_VERSION lt $LFS_CURRENT_VERSION; then


### PR DESCRIPTION
- Removed the tests step from `check-hooks-pr.yml`, otherwise, if there are new hooks the tests will
fail and a PR won't be created
- Exiting with a failure code from the `update-from-git-lfs.sh` script when the version has not changed, so as not to submit a PR